### PR TITLE
Remove property shorthands for IE compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,12 +71,12 @@ FakeProgress.prototype.createSubProgress = function (opts) {
 	const parentStart = opts.start || this.progress;
 	const parentEnd = opts.end || 1;
 	const options = Object.assign({}, opts, {
-    parent: this,
-    parentStart: parentStart,
-    parentEnd: parentEnd,
-    start: null,
-    end: null
-  });
+		parent: this,
+		parentStart: parentStart,
+		parentEnd: parentEnd,
+		start: null,
+		end: null
+	});
 	const subProgress = new FakeProgress(options);
 	return subProgress;
 };

--- a/index.js
+++ b/index.js
@@ -70,7 +70,13 @@ FakeProgress.prototype.stop = function () {
 FakeProgress.prototype.createSubProgress = function (opts) {
 	const parentStart = opts.start || this.progress;
 	const parentEnd = opts.end || 1;
-	const options = Object.assign({}, opts, {parent: this, parentStart, parentEnd, start: null, end: null});
+	const options = Object.assign({}, opts, {
+    parent: this,
+    parentStart: parentStart,
+    parentEnd: parentEnd,
+    start: null,
+    end: null
+  });
 	const subProgress = new FakeProgress(options);
 	return subProgress;
 };


### PR DESCRIPTION
Had a compatibility problem with IE. It was caused by property shorthands. Removed them on the corresponding place.
Object.assign is still a problem for IE, but can be solved with babel-polyfill.